### PR TITLE
small correction for the "single" deployment

### DIFF
--- a/samples/helm/templates/devportal.yaml
+++ b/samples/helm/templates/devportal.yaml
@@ -11,10 +11,12 @@ metadata:
   labels:
     app: {{ $.Values.productName }}
 spec:
+{{- if eq $.Values.deploymentType "cluster" }}
   podManagementPolicy: Parallel
+  serviceName: {{ $.Values.productName }}-svc
+{{- end }}
   replicas: {{ include "devportal.appSpecific.getdeploymentTypeConfigAsYaml" (dict "application" $app "config" "replica" "root" $) }}
   revisionHistoryLimit: 10
-  serviceName: {{ $.Values.productName }}-svc
   selector:
     matchLabels:
       app: {{ $.Values.productName }}


### PR DESCRIPTION
corrected developer portal "single" deployment to avoid having 'podManagementPolicy' and 'serviceName' in the Deployment spec. Otherwise, installing the helm chart fails.